### PR TITLE
Frezze jocaaguraarchetype (#31)

### DIFF
--- a/.github/workflows/validate_pr.yaml
+++ b/.github/workflows/validate_pr.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.27.1'
+          channel: stable
 
       - name: Validate Changelog Update
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.0.2] - 2025-08-27
+
+### 🔒 Resolved master conflicts
+
+## [2.0.1] - 2025-08-27
+
+### 🔒 Congelación de `pubspec.yaml`
+
+Esta versión congela el archivo `pubspec.yaml` como parte del proceso de migración de lógica de negocio hacia el paquete [`jocaagura_domain`](https://pub.dev/packages/jocaagura_domain), a partir de su versión `1.21.2`.
+**⚠️ Importante:**  
+No se recibirán actualizaciones ni nuevas dependencias en este paquete hasta que la migración completa esté finalizada. Esto garantiza estabilidad durante el refactor estructural y evita conflictos en entornos de integración continua.
+
+---
+
 ## [2.0.0] - 2025-07-27
 
 ### ⚠️ Breaking Changes
@@ -37,6 +52,35 @@ Este cambio mayor responde a una estrategia de consolidación de herramientas tr
 > ⚠️ Este paquete podría ser deprecado en el futuro. Se recomienda utilizar directamente `jocaagura_domain` como punto de entrada para la configuración de servicios compartidos y lógica transversal.
 
 
+
+## [1.5.2] - 2025-01-16
+
+### Improved
+- Enhanced the `publish.yml` workflow to accommodate the Google environment and GitHub Actions, ensuring seamless package publishing.
+
+## [2.0.1] - 2025-08-27
+
+### 🔒 Congelación de `pubspec.yaml`
+
+Esta versión congela el archivo `pubspec.yaml` como parte del proceso de migración de lógica de negocio hacia el paquete [`jocaagura_domain`](https://pub.dev/packages/jocaagura_domain), a partir de su versión `1.21.2`.
+**⚠️ Importante:**  
+No se recibirán actualizaciones ni nuevas dependencias en este paquete hasta que la migración completa esté finalizada. Esto garantiza estabilidad durante el refactor estructural y evita conflictos en entornos de integración continua.
+
+---
+
+### 🧭 Contexto
+
+La lógica compartida, los contratos y modelos principales serán trasladados progresivamente a `jocaagura_domain` para favorecer la reutilización, testabilidad y mantenimiento centralizado.
+
+---
+
+### 📌 Próximos pasos
+- Migrar los `Blocs`, `Gateways`, `Repositories` y `Entities` existentes a `jocaagura_domain`.
+- Eliminar código duplicado tras la consolidación.
+- Actualizar documentación de dependencias y estructura de carpetas.
+
+---
+Si estás utilizando este paquete en tus proyectos, asegúrate de apuntar tus dependencias compartidas directamente a `jocaagura_domain` en adelante.
 
 ## [1.5.2] - 2025-01-16
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,9 @@ name: jocaaguraarchetype
 description: >
   Paquete base para inicializar rápidamente proyectos Flutter usando Jocaagura Clean Architecture.
   ⚠️ Este paquete podría ser deprecado. Se recomienda usar directamente jocaagura_domain para una mejor mantenibilidad.
-version: 2.0.0
+
+version: 2.0.2
+
 homepage: https://github.com/jocaagura/jocaaguraarchetype
 repository: https://github.com/jocaagura/jocaaguraarchetype
 
@@ -13,10 +15,11 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  jocaagura_domain: ^1.21.2
+    
+  jocaagura_domain: 1.21.2
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
 


### PR DESCRIPTION
* fix(albertjjimenezp): issue #22 optimizacion de tareas de github (#24)

* fix(albertjjimenezp): issue #22 optimizacion de tareas de github

* Bump version to 1.5.2

---------



* feat(albertjjimenezp): issue #26 -  migrate shared services to jocaaura_domain and prepare for deprecation (#27)

* feat(albertjjimenezp): issue #26 -  migrate shared services to jocaagura_domain and prepare for deprecation

                               BREAKING CHANGE:
                               - Removed internal implementations of ServiceSession and ServiceConnectivity.
                               - Introduced dependency on jocaagura_domain for core cross-functional services.
                               - Refactored blocs to align with the new contracts in jocaagura_domain.

                               This package is no longer a standalone solution and may be deprecated in the near future.
                               Developers are encouraged to migrate their apps to jocaagura_domain to ensure long-term compatibility and simplified maintenance.

* feat(albertjjimenezp): issue #26 B -  migrate shared services to jocaagura_domain and prepare for deprecation

                               BREAKING CHANGE:
                               - Removed internal implementations of ServiceSession and ServiceConnectivity.
                               - Introduced dependency on jocaagura_domain for core cross-functional services.
                               - Refactored blocs to align with the new contracts in jocaagura_domain.

                               This package is no longer a standalone solution and may be deprecated in the near future.
                               Developers are encouraged to migrate their apps to jocaagura_domain to ensure long-term compatibility and simplified maintenance.

* Bump version to 2.0.0

---------



* 29 freeze jocaagura domain (#30)

* Upgrade package.dev (#28)

* fix(albertjjimenezp): issue #22 optimizacion de tareas de github (#24)

* fix(albertjjimenezp): issue #22 optimizacion de tareas de github

* Bump version to 1.5.2

---------



* feat(albertjjimenezp): issue #26 -  migrate shared services to jocaaura_domain and prepare for deprecation (#27)

* feat(albertjjimenezp): issue #26 -  migrate shared services to jocaagura_domain and prepare for deprecation

                               BREAKING CHANGE:
                               - Removed internal implementations of ServiceSession and ServiceConnectivity.
                               - Introduced dependency on jocaagura_domain for core cross-functional services.
                               - Refactored blocs to align with the new contracts in jocaagura_domain.

                               This package is no longer a standalone solution and may be deprecated in the near future.
                               Developers are encouraged to migrate their apps to jocaagura_domain to ensure long-term compatibility and simplified maintenance.

* feat(albertjjimenezp): issue #26 B -  migrate shared services to jocaagura_domain and prepare for deprecation

                               BREAKING CHANGE:
                               - Removed internal implementations of ServiceSession and ServiceConnectivity.
                               - Introduced dependency on jocaagura_domain for core cross-functional services.
                               - Refactored blocs to align with the new contracts in jocaagura_domain.

                               This package is no longer a standalone solution and may be deprecated in the near future.
                               Developers are encouraged to migrate their apps to jocaagura_domain to ensure long-term compatibility and simplified maintenance.

* Bump version to 2.0.0

---------



---------



* chore(@albertjjimenezp): congelar pubspec.yaml para migración a jocaagura_domain@1.21.2

Se congela el archivo pubspec.yaml para garantizar estabilidad durante la migración de lógica de negocio hacia el paquete jocaagura_domain. No se permitirán nuevas dependencias hasta que se complete la transición.

* chore(@albertjjimenezp): congelar pubspec.yaml para migración a jocaagura_domain@1.21.2 Revision previa para actualizacion de github actions. Se congela el archivo pubspec.yaml para garantizar estabilidad durante la migración de lógica de negocio hacia el paquete jocaagura_domain. No se permitirán nuevas dependencias hasta que se complete la transición.

* Bump version to 2.0.1

---------



* Resolve master conflits with develop (#32)

* Upgrade package.dev (#28)

* fix(albertjjimenezp): issue #22 optimizacion de tareas de github (#24)

* fix(albertjjimenezp): issue #22 optimizacion de tareas de github

* Bump version to 1.5.2

---------



* feat(albertjjimenezp): issue #26 -  migrate shared services to jocaaura_domain and prepare for deprecation (#27)

* feat(albertjjimenezp): issue #26 -  migrate shared services to jocaagura_domain and prepare for deprecation

                               BREAKING CHANGE:
                               - Removed internal implementations of ServiceSession and ServiceConnectivity.
                               - Introduced dependency on jocaagura_domain for core cross-functional services.
                               - Refactored blocs to align with the new contracts in jocaagura_domain.

                               This package is no longer a standalone solution and may be deprecated in the near future.
                               Developers are encouraged to migrate their apps to jocaagura_domain to ensure long-term compatibility and simplified maintenance.

* feat(albertjjimenezp): issue #26 B -  migrate shared services to jocaagura_domain and prepare for deprecation

                               BREAKING CHANGE:
                               - Removed internal implementations of ServiceSession and ServiceConnectivity.
                               - Introduced dependency on jocaagura_domain for core cross-functional services.
                               - Refactored blocs to align with the new contracts in jocaagura_domain.

                               This package is no longer a standalone solution and may be deprecated in the near future.
                               Developers are encouraged to migrate their apps to jocaagura_domain to ensure long-term compatibility and simplified maintenance.

* Bump version to 2.0.0

---------



---------



* chore(@albertjjimenezp): Resolve master branch conflicts

* Bump version to 2.0.2

---------



---------